### PR TITLE
[ET-VK] Add VK_KHR_cooperative_matrix MatMul shaders and benchmark

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/addmm_khr_cm.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/addmm_khr_cm.glsl
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * KHR Cooperative Matrix matmul/addmm shader.
+ * Computes: D = alpha * A * B + beta * C  (HAS_BIAS=true)
+ *       or: D = A * B                     (HAS_BIAS=false)
+ *
+ * A: [M, K] row-major buffer
+ * B: [K, N] row-major buffer (or col-major if BColMajor)
+ * C: [M, N] row-major buffer (bias, only when HAS_BIAS)
+ * D: [M, N] row-major buffer (output)
+ *
+ * Uses shared memory tiling with double-buffered prefetch for
+ * hiding global memory latency behind cooperative matrix math.
+ */
+
+#version 450 core
+#pragma use_vulkan_memory_model
+
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+#extension GL_EXT_control_flow_attributes : enable
+
+$if A_DTYPE == "half":
+  #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+  #define A_BITS 16
+  #define A_SCALAR_TYPE float16_t
+
+$if A_DTYPE == "float":
+  #define A_BITS 32
+  #define A_SCALAR_TYPE float
+
+$if DTYPE == "half":
+  #define C_SCALAR_TYPE float16_t
+
+$if DTYPE == "float":
+  #define C_SCALAR_TYPE float
+
+layout(std430) buffer;
+
+// Buffer bindings: D (output), A (uvec4 input), B (uvec4 input), C (bias)
+layout(set = 0, binding = 0) buffer restrict writeonly DBuffer {
+    C_SCALAR_TYPE t_D[];
+};
+layout(set = 0, binding = 1) buffer restrict readonly AV4Buffer {
+    uvec4 t_A_v4[];
+};
+layout(set = 0, binding = 2) buffer restrict readonly BV4Buffer {
+    uvec4 t_B_v4[];
+};
+$if HAS_BIAS:
+  layout(set = 0, binding = 3) buffer restrict readonly CBuffer {
+      C_SCALAR_TYPE t_C[];
+  };
+
+// Runtime-varying parameters via push constants
+layout(push_constant) uniform restrict Block {
+    uint K;
+    uint strideA;
+    uint strideB;
+    uint strideC;
+    uint strideD;
+    float alpha;
+    float beta;
+};
+
+// Workgroup size set via specialization constants (IDs 0-2)
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+// Cooperative matrix tile dimensions (IDs 3+)
+layout(constant_id = 3) const uint lM = 16;
+layout(constant_id = 4) const uint lN = 16;
+layout(constant_id = 5) const uint lK = 16;
+layout(constant_id = 6) const uint TILE_M = 128;
+layout(constant_id = 7) const uint TILE_N = 128;
+layout(constant_id = 8) const uint TILE_K = 32;
+layout(constant_id = 9) const uint A_ROW_LEN = 32;
+layout(constant_id = 10) const uint A_NUM_ROWS = 128;
+layout(constant_id = 11) const uint B_ROW_LEN = 128;
+layout(constant_id = 12) const uint B_NUM_ROWS = 32;
+layout(constant_id = 13) const uint BColMajor_val = 0;
+
+const bool BColMajor = (BColMajor_val != 0);
+
+// Elements per uvec4 load (128 bits / element size in bits)
+const uint ELEMENTS_PER_VEC4 = 16 / (A_BITS / 8);
+const uint ROW_PAD_SH = ELEMENTS_PER_VEC4;
+
+// Shared memory with skew padding to avoid bank conflicts
+shared uvec4 Ash[A_NUM_ROWS * (A_ROW_LEN + ROW_PAD_SH) / ELEMENTS_PER_VEC4];
+shared uvec4 Bsh[B_NUM_ROWS * (B_ROW_LEN + ROW_PAD_SH) / ELEMENTS_PER_VEC4];
+
+const uint WORKGROUP_WIDTH_IN_SUBGROUPS = 4;
+const uint WORKGROUP_HEIGHT_IN_SUBGROUPS = 2;
+const uint NUM_SUBGROUPS = WORKGROUP_WIDTH_IN_SUBGROUPS * WORKGROUP_HEIGHT_IN_SUBGROUPS;
+const uint INVOCATIONS_PER_WORKGROUP = 32 * NUM_SUBGROUPS;
+
+const uint C_ROWS = TILE_M / WORKGROUP_HEIGHT_IN_SUBGROUPS / lM;
+const uint C_COLS = TILE_N / WORKGROUP_WIDTH_IN_SUBGROUPS / lN;
+
+coopmat<C_SCALAR_TYPE, gl_ScopeSubgroup, lM, lN, gl_MatrixUseAccumulator> result[C_ROWS][C_COLS];
+
+uint coordToOffset(uint i, uint j, uint stride, bool colMajor) {
+    return colMajor ? (stride * j + i) : (stride * i + j);
+}
+
+void main() {
+    uvec2 tileID = uvec2(gl_WorkGroupID.xy);
+    uvec2 warpInTile = uvec2(
+        gl_SubgroupID % WORKGROUP_WIDTH_IN_SUBGROUPS,
+        gl_SubgroupID / WORKGROUP_WIDTH_IN_SUBGROUPS);
+
+    // Initialize result to zero
+    [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+        [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+            result[i][j] = coopmat<C_SCALAR_TYPE, gl_ScopeSubgroup, lM, lN, gl_MatrixUseAccumulator>(0.0);
+        }
+    }
+
+    uint chunkK = 0;
+
+    // Prefetch A tile from global to registers
+    const uint INVS_PER_ROW_A = A_ROW_LEN / ELEMENTS_PER_VEC4;
+    uint atilek = ELEMENTS_PER_VEC4 * (gl_LocalInvocationID.x % INVS_PER_ROW_A);
+
+    uvec4 temp_A[A_NUM_ROWS / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)];
+    uint gabase = coordToOffset(TILE_M * tileID.y, chunkK, strideA, false);
+    [[unroll]] for (uint i = 0; i < A_NUM_ROWS; i += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A) {
+        uint atilei = i + gl_LocalInvocationID.x / INVS_PER_ROW_A;
+        temp_A[i / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)] =
+            t_A_v4[(gabase + strideA * atilei + atilek) / ELEMENTS_PER_VEC4];
+    }
+
+    // Prefetch B tile from global to registers
+    const uint INVS_PER_ROW_B = B_ROW_LEN / ELEMENTS_PER_VEC4;
+    uint btilej = ELEMENTS_PER_VEC4 * (gl_LocalInvocationID.x % INVS_PER_ROW_B);
+
+    uvec4 temp_B[B_NUM_ROWS / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)];
+    uint gbbase = coordToOffset(chunkK, TILE_N * tileID.x, strideB, BColMajor);
+    [[unroll]] for (uint k = 0; k < B_NUM_ROWS; k += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B) {
+        uint btilek = k + gl_LocalInvocationID.x / INVS_PER_ROW_B;
+        temp_B[k / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)] =
+            t_B_v4[(gbbase + strideB * btilek + btilej) / ELEMENTS_PER_VEC4];
+    }
+
+    // Main K-loop: tile over K dimension
+    for (uint chunkK = 0; chunkK < K; chunkK += TILE_K) {
+        bool last = ((chunkK + TILE_K) >= K);
+
+        const uint STRIDE_A_SH = (A_ROW_LEN + ROW_PAD_SH);
+
+        // Ensure previous iteration's shared memory reads are complete
+        barrier();
+
+        // Store A from registers to shared memory
+        [[unroll]] for (uint i = 0; i < A_NUM_ROWS; i += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A) {
+            uint si = i + gl_LocalInvocationID.x / INVS_PER_ROW_A;
+            Ash[(STRIDE_A_SH * si + atilek) / ELEMENTS_PER_VEC4] =
+                temp_A[i / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)];
+        }
+
+        const uint STRIDE_B_SH = (B_ROW_LEN + ROW_PAD_SH);
+
+        // Store B from registers to shared memory
+        [[unroll]] for (uint k = 0; k < B_NUM_ROWS; k += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B) {
+            uint sk = k + gl_LocalInvocationID.x / INVS_PER_ROW_B;
+            Bsh[(STRIDE_B_SH * sk + btilej) / ELEMENTS_PER_VEC4] =
+                temp_B[k / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)];
+        }
+
+        // Wait for shared memory writes before math
+        barrier();
+
+        // Prefetch next A tile (hide latency behind math)
+        uint gabase_next = coordToOffset(TILE_M * tileID.y, chunkK + TILE_K, strideA, false);
+        [[unroll]] for (uint i = 0; i < A_NUM_ROWS; i += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A) {
+            uint atilei = i + gl_LocalInvocationID.x / INVS_PER_ROW_A;
+            if (!last) {
+                temp_A[i / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)] =
+                    t_A_v4[(gabase_next + strideA * atilei + atilek) / ELEMENTS_PER_VEC4];
+            }
+        }
+
+        // Prefetch next B tile
+        uint gbbase_next = coordToOffset(chunkK + TILE_K, TILE_N * tileID.x, strideB, BColMajor);
+        [[unroll]] for (uint k = 0; k < B_NUM_ROWS; k += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B) {
+            uint btilek = k + gl_LocalInvocationID.x / INVS_PER_ROW_B;
+            if (!last) {
+                temp_B[k / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)] =
+                    t_B_v4[(gbbase_next + strideB * btilek + btilej) / ELEMENTS_PER_VEC4];
+            }
+        }
+
+        // Cooperative matrix multiply-accumulate from shared memory
+        [[unroll]] for (uint k = 0; k < TILE_K / lK; ++k) {
+            uint sk = lK * k;
+
+            // Load A tiles (reused across C_COLS)
+            coopmat<A_SCALAR_TYPE, gl_ScopeSubgroup, lM, lK, gl_MatrixUseA> matA[C_ROWS];
+            [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+                uint si = lM * (C_ROWS * warpInTile.y + i);
+                coopMatLoad(
+                    matA[i], Ash,
+                    coordToOffset(si, sk, STRIDE_A_SH, false) / ELEMENTS_PER_VEC4,
+                    STRIDE_A_SH / ELEMENTS_PER_VEC4,
+                    gl_CooperativeMatrixLayoutRowMajor);
+            }
+
+            // Load B tile and multiply
+            coopmat<A_SCALAR_TYPE, gl_ScopeSubgroup, lK, lN, gl_MatrixUseB> matB;
+            [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+                uint sj = lN * (C_COLS * warpInTile.x + j);
+                coopMatLoad(
+                    matB, Bsh,
+                    coordToOffset(sk, sj, STRIDE_B_SH, BColMajor) / ELEMENTS_PER_VEC4,
+                    STRIDE_B_SH / ELEMENTS_PER_VEC4,
+                    BColMajor ? gl_CooperativeMatrixLayoutColumnMajor : gl_CooperativeMatrixLayoutRowMajor);
+
+                [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+                    result[i][j] = coopMatMulAdd(matA[i], matB, result[i][j]);
+                }
+            }
+        }
+    }
+
+    // Write output
+$if HAS_BIAS:
+    // D = alpha * (A * B) + beta * C
+    [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+        uint gi = TILE_M * tileID.y + lM * (C_ROWS * warpInTile.y + i);
+        coopmat<C_SCALAR_TYPE, gl_ScopeSubgroup, lM, lN, gl_MatrixUseAccumulator> matC[C_COLS];
+
+        [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+            uint gj = TILE_N * tileID.x + lN * (C_COLS * warpInTile.x + j);
+            coopMatLoad(
+                matC[j], t_C,
+                coordToOffset(gi, gj, strideC, false),
+                strideC,
+                gl_CooperativeMatrixLayoutRowMajor);
+        }
+
+        [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+            uint gj = TILE_N * tileID.x + lN * (C_COLS * warpInTile.x + j);
+
+            result[i][j] = C_SCALAR_TYPE(alpha) * result[i][j] + C_SCALAR_TYPE(beta) * matC[j];
+            coopMatStore(
+                result[i][j], t_D,
+                coordToOffset(gi, gj, strideD, false),
+                strideD,
+                gl_CooperativeMatrixLayoutRowMajor);
+        }
+    }
+$else:
+    // D = A * B (no bias)
+    [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+        [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+            uint gi = TILE_M * tileID.y + lM * (C_ROWS * warpInTile.y + i);
+            uint gj = TILE_N * tileID.x + lN * (C_COLS * warpInTile.x + j);
+
+            coopMatStore(
+                result[i][j], t_D,
+                coordToOffset(gi, gj, strideD, false),
+                strideD,
+                gl_CooperativeMatrixLayoutRowMajor);
+        }
+    }
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/addmm_khr_cm.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/addmm_khr_cm.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+addmm_khr_cm:
+  parameter_names_with_default_values:
+    DTYPE: float
+    A_DTYPE: float
+    PRECISION: highp
+    HAS_BIAS: false
+  generate_variant_forall:
+    A_DTYPE:
+      - VALUE: half
+        SUFFIX: half
+      - VALUE: float
+        SUFFIX: float
+  shader_variants:
+    - NAME: matmul_khr_cm
+    - NAME: addmm_khr_cm
+      HAS_BIAS: true

--- a/backends/vulkan/runtime/graph/ops/glsl/matmul_khr_cm_int8.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/matmul_khr_cm_int8.glsl
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * KHR Cooperative Matrix int8 GEMM shader.
+ * Computes: D = A * B (pure integer matmul, no dequantization)
+ *
+ * A: [M, K] row-major buffer (int8)
+ * B: [K, N] row-major buffer (int8)
+ * D: [M, N] row-major buffer (int32 accumulator output)
+ *
+ * Uses shared memory tiling with double-buffered prefetch,
+ * same architecture as the FP16 addmm_khr_cm.glsl shader.
+ */
+
+#version 450 core
+#pragma use_vulkan_memory_model
+
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_control_flow_attributes : enable
+
+#define A_BITS 8
+#define A_SCALAR_TYPE uint8_t
+#define C_SCALAR_TYPE uint32_t
+
+layout(std430) buffer;
+
+// Buffer bindings: D (float output — int32 accumulator cast to float), A (uvec4 input), B (uvec4 input)
+layout(set = 0, binding = 0) buffer restrict writeonly DBuffer {
+    float t_D[];
+};
+layout(set = 0, binding = 1) buffer restrict readonly AV4Buffer {
+    uvec4 t_A_v4[];
+};
+layout(set = 0, binding = 2) buffer restrict readonly BV4Buffer {
+    uvec4 t_B_v4[];
+};
+
+// Push constants: K and strides only (no alpha/beta for pure integer GEMM)
+layout(push_constant) uniform restrict Block {
+    uint K;
+    uint strideA;
+    uint strideB;
+    uint strideD;
+};
+
+// Workgroup size set via specialization constants (IDs 0-2)
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+// Cooperative matrix tile dimensions (IDs 3+)
+layout(constant_id = 3) const uint lM = 16;
+layout(constant_id = 4) const uint lN = 16;
+layout(constant_id = 5) const uint lK = 16;
+layout(constant_id = 6) const uint TILE_M = 128;
+layout(constant_id = 7) const uint TILE_N = 128;
+layout(constant_id = 8) const uint TILE_K = 32;
+layout(constant_id = 9) const uint A_ROW_LEN = 32;
+layout(constant_id = 10) const uint A_NUM_ROWS = 128;
+layout(constant_id = 11) const uint B_ROW_LEN = 128;
+layout(constant_id = 12) const uint B_NUM_ROWS = 32;
+layout(constant_id = 13) const uint BColMajor_val = 0;
+
+const bool BColMajor = (BColMajor_val != 0);
+
+// Elements per uvec4 load: 16 bytes / 1 byte per int8 = 16 elements
+const uint ELEMENTS_PER_VEC4 = 16 / (A_BITS / 8);
+const uint ROW_PAD_SH = ELEMENTS_PER_VEC4;
+
+// Shared memory with skew padding to avoid bank conflicts
+shared uvec4 Ash[A_NUM_ROWS * (A_ROW_LEN + ROW_PAD_SH) / ELEMENTS_PER_VEC4];
+shared uvec4 Bsh[B_NUM_ROWS * (B_ROW_LEN + ROW_PAD_SH) / ELEMENTS_PER_VEC4];
+
+const uint WORKGROUP_WIDTH_IN_SUBGROUPS = 4;
+const uint WORKGROUP_HEIGHT_IN_SUBGROUPS = 2;
+const uint NUM_SUBGROUPS = WORKGROUP_WIDTH_IN_SUBGROUPS * WORKGROUP_HEIGHT_IN_SUBGROUPS;
+const uint INVOCATIONS_PER_WORKGROUP = 32 * NUM_SUBGROUPS;
+
+const uint C_ROWS = TILE_M / WORKGROUP_HEIGHT_IN_SUBGROUPS / lM;
+const uint C_COLS = TILE_N / WORKGROUP_WIDTH_IN_SUBGROUPS / lN;
+
+// Int32 accumulator cooperative matrices
+coopmat<C_SCALAR_TYPE, gl_ScopeSubgroup, lM, lN, gl_MatrixUseAccumulator> result[C_ROWS][C_COLS];
+
+uint coordToOffset(uint i, uint j, uint stride, bool colMajor) {
+    return colMajor ? (stride * j + i) : (stride * i + j);
+}
+
+void main() {
+    uvec2 tileID = uvec2(gl_WorkGroupID.xy);
+    uvec2 warpInTile = uvec2(
+        gl_SubgroupID % WORKGROUP_WIDTH_IN_SUBGROUPS,
+        gl_SubgroupID / WORKGROUP_WIDTH_IN_SUBGROUPS);
+
+    // Initialize result to zero (integer)
+    [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+        [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+            result[i][j] = coopmat<C_SCALAR_TYPE, gl_ScopeSubgroup, lM, lN, gl_MatrixUseAccumulator>(0);
+        }
+    }
+
+    uint chunkK = 0;
+
+    // Prefetch A tile from global to registers
+    const uint INVS_PER_ROW_A = A_ROW_LEN / ELEMENTS_PER_VEC4;
+    uint atilek = ELEMENTS_PER_VEC4 * (gl_LocalInvocationID.x % INVS_PER_ROW_A);
+
+    uvec4 temp_A[A_NUM_ROWS / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)];
+    uint gabase = coordToOffset(TILE_M * tileID.y, chunkK, strideA, false);
+    [[unroll]] for (uint i = 0; i < A_NUM_ROWS; i += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A) {
+        uint atilei = i + gl_LocalInvocationID.x / INVS_PER_ROW_A;
+        temp_A[i / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)] =
+            t_A_v4[(gabase + strideA * atilei + atilek) / ELEMENTS_PER_VEC4];
+    }
+
+    // Prefetch B tile from global to registers
+    const uint INVS_PER_ROW_B = B_ROW_LEN / ELEMENTS_PER_VEC4;
+    uint btilej = ELEMENTS_PER_VEC4 * (gl_LocalInvocationID.x % INVS_PER_ROW_B);
+
+    uvec4 temp_B[B_NUM_ROWS / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)];
+    uint gbbase = coordToOffset(chunkK, TILE_N * tileID.x, strideB, BColMajor);
+    [[unroll]] for (uint k = 0; k < B_NUM_ROWS; k += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B) {
+        uint btilek = k + gl_LocalInvocationID.x / INVS_PER_ROW_B;
+        temp_B[k / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)] =
+            t_B_v4[(gbbase + strideB * btilek + btilej) / ELEMENTS_PER_VEC4];
+    }
+
+    // Main K-loop: tile over K dimension
+    for (uint chunkK = 0; chunkK < K; chunkK += TILE_K) {
+        bool last = ((chunkK + TILE_K) >= K);
+
+        const uint STRIDE_A_SH = (A_ROW_LEN + ROW_PAD_SH);
+
+        barrier();
+
+        // Store A from registers to shared memory
+        [[unroll]] for (uint i = 0; i < A_NUM_ROWS; i += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A) {
+            uint si = i + gl_LocalInvocationID.x / INVS_PER_ROW_A;
+            Ash[(STRIDE_A_SH * si + atilek) / ELEMENTS_PER_VEC4] =
+                temp_A[i / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)];
+        }
+
+        const uint STRIDE_B_SH = (B_ROW_LEN + ROW_PAD_SH);
+
+        // Store B from registers to shared memory
+        [[unroll]] for (uint k = 0; k < B_NUM_ROWS; k += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B) {
+            uint sk = k + gl_LocalInvocationID.x / INVS_PER_ROW_B;
+            Bsh[(STRIDE_B_SH * sk + btilej) / ELEMENTS_PER_VEC4] =
+                temp_B[k / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)];
+        }
+
+        barrier();
+
+        // Prefetch next A tile
+        uint gabase_next = coordToOffset(TILE_M * tileID.y, chunkK + TILE_K, strideA, false);
+        [[unroll]] for (uint i = 0; i < A_NUM_ROWS; i += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A) {
+            uint atilei = i + gl_LocalInvocationID.x / INVS_PER_ROW_A;
+            if (!last) {
+                temp_A[i / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_A)] =
+                    t_A_v4[(gabase_next + strideA * atilei + atilek) / ELEMENTS_PER_VEC4];
+            }
+        }
+
+        // Prefetch next B tile
+        uint gbbase_next = coordToOffset(chunkK + TILE_K, TILE_N * tileID.x, strideB, BColMajor);
+        [[unroll]] for (uint k = 0; k < B_NUM_ROWS; k += INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B) {
+            uint btilek = k + gl_LocalInvocationID.x / INVS_PER_ROW_B;
+            if (!last) {
+                temp_B[k / (INVOCATIONS_PER_WORKGROUP / INVS_PER_ROW_B)] =
+                    t_B_v4[(gbbase_next + strideB * btilek + btilej) / ELEMENTS_PER_VEC4];
+            }
+        }
+
+        // Cooperative matrix multiply-accumulate from shared memory
+        [[unroll]] for (uint k = 0; k < TILE_K / lK; ++k) {
+            uint sk = lK * k;
+
+            // Load int8 A tiles
+            coopmat<A_SCALAR_TYPE, gl_ScopeSubgroup, lM, lK, gl_MatrixUseA> matA[C_ROWS];
+            [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+                uint si = lM * (C_ROWS * warpInTile.y + i);
+                coopMatLoad(
+                    matA[i], Ash,
+                    coordToOffset(si, sk, STRIDE_A_SH, false) / ELEMENTS_PER_VEC4,
+                    STRIDE_A_SH / ELEMENTS_PER_VEC4,
+                    gl_CooperativeMatrixLayoutRowMajor);
+            }
+
+            // Load int8 B tile and multiply-accumulate into int32
+            coopmat<A_SCALAR_TYPE, gl_ScopeSubgroup, lK, lN, gl_MatrixUseB> matB;
+            [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+                uint sj = lN * (C_COLS * warpInTile.x + j);
+                coopMatLoad(
+                    matB, Bsh,
+                    coordToOffset(sk, sj, STRIDE_B_SH, BColMajor) / ELEMENTS_PER_VEC4,
+                    STRIDE_B_SH / ELEMENTS_PER_VEC4,
+                    BColMajor ? gl_CooperativeMatrixLayoutColumnMajor : gl_CooperativeMatrixLayoutRowMajor);
+
+                [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+                    result[i][j] = coopMatMulAdd(matA[i], matB, result[i][j]);
+                }
+            }
+        }
+    }
+
+    // Convert uint32 accumulator to float and store.
+    // coopMatStore of float to global memory works reliably (proven by FP16 shader).
+    [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
+        [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+            uint gi = TILE_M * tileID.y + lM * (C_ROWS * warpInTile.y + i);
+            uint gj = TILE_N * tileID.x + lN * (C_COLS * warpInTile.x + j);
+
+            // Convert uint32 cooperative matrix to float
+            coopmat<float, gl_ScopeSubgroup, lM, lN, gl_MatrixUseAccumulator> float_result =
+                coopmat<float, gl_ScopeSubgroup, lM, lN, gl_MatrixUseAccumulator>(result[i][j]);
+
+            coopMatStore(
+                float_result, t_D,
+                gi * strideD + gj,
+                strideD,
+                gl_CooperativeMatrixLayoutRowMajor);
+        }
+    }
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/matmul_khr_cm_int8.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/matmul_khr_cm_int8.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+matmul_khr_cm_int8:
+  parameter_names_with_default_values:
+    PRECISION: highp
+  shader_variants:
+    - NAME: matmul_khr_cm_int8

--- a/backends/vulkan/runtime/graph/ops/impl/MatMulKHRCoopMat.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/MatMulKHRCoopMat.cpp
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+//
+// KHR Cooperative Matrix GEMM operator
+//
+// Computes D = alpha * A * B + beta * C using GL_KHR_cooperative_matrix.
+// Cross-vendor: works on Qualcomm, ARM, Intel, NVIDIA.
+//
+// Shader: runtime/graph/ops/glsl/addmm_khr_cm.glsl
+// Variants: matmul_khr_cm_{half,float} (no bias)
+//           addmm_khr_cm_{half,float}  (with bias)
+//
+
+// Tile configuration — must match shader workgroup layout.
+// Workgroup: 8 subgroups (4 wide x 2 high) x 32 threads = 256 threads.
+// Cooperative matrix dimensions: lM=lN=lK=16.
+static constexpr uint32_t kDefaultLM = 16;
+static constexpr uint32_t kDefaultLN = 16;
+static constexpr uint32_t kDefaultLK = 16;
+static constexpr uint32_t kDefaultTileM = 128;
+static constexpr uint32_t kDefaultTileN = 128;
+static constexpr uint32_t kDefaultTileK = 32;
+
+static constexpr uint32_t kWorkgroupWidthInSubgroups = 4;
+static constexpr uint32_t kWorkgroupHeightInSubgroups = 2;
+static constexpr uint32_t kInvocationsPerWorkgroup =
+    32 * kWorkgroupWidthInSubgroups * kWorkgroupHeightInSubgroups;
+
+// Derived tile dimensions for shared memory layout
+static constexpr uint32_t kDefaultARowLen = kDefaultTileK;
+static constexpr uint32_t kDefaultANumRows = kDefaultTileM;
+static constexpr uint32_t kDefaultBRowLen = kDefaultTileN;
+static constexpr uint32_t kDefaultBNumRows = kDefaultTileK;
+
+// Push constant blocks (each must be <= 16 bytes)
+struct KhrCmPushBlock1 {
+  uint32_t K;
+  uint32_t strideA;
+  uint32_t strideB;
+  uint32_t strideC;
+};
+
+struct KhrCmPushBlock2 {
+  uint32_t strideD;
+  float alpha;
+  float beta;
+};
+
+//
+// Shader dispatch utilities
+//
+
+void resize_khr_cm_gemm_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)extra_args;
+
+  const ValueRef output = args.at(0).refs.at(0);
+  const ValueRef mat1 = args.at(1).refs.at(0);
+  const ValueRef mat2 = args.at(1).refs.at(1);
+
+  const std::vector<int64_t> mat1_sizes = graph->sizes_of(mat1);
+  const std::vector<int64_t> mat2_sizes = graph->sizes_of(mat2);
+
+  const int64_t M = utils::val_at(-2, mat1_sizes);
+  const int64_t N = utils::val_at(-1, mat2_sizes);
+
+  std::vector<int64_t> new_out_sizes(mat1_sizes.size());
+  if (mat1_sizes.size() == 2) {
+    new_out_sizes.at(0) = M;
+    new_out_sizes.at(1) = N;
+  } else {
+    new_out_sizes.at(0) = mat1_sizes.at(0);
+    new_out_sizes.at(1) = M;
+    new_out_sizes.at(2) = N;
+  }
+
+  graph->virtual_resize(output, new_out_sizes);
+}
+
+// Shader selection: matmul (no bias) variant
+vkapi::ShaderInfo pick_matmul_khr_cm_shader(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)resize_args;
+  const ValueRef mat1 = args.at(1).refs.at(0);
+
+  std::string kernel_name = "matmul_khr_cm";
+  add_dtype_suffix(kernel_name, graph->dtype_of(mat1));
+
+  return VK_KERNEL_FROM_STR(kernel_name);
+}
+
+// Shader selection: addmm (with bias) variant
+vkapi::ShaderInfo pick_addmm_khr_cm_shader(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)resize_args;
+  const ValueRef mat1 = args.at(1).refs.at(0);
+
+  std::string kernel_name = "addmm_khr_cm";
+  add_dtype_suffix(kernel_name, graph->dtype_of(mat1));
+
+  return VK_KERNEL_FROM_STR(kernel_name);
+}
+
+// Global workgroup size: 2D grid of tiles
+utils::uvec3 khr_cm_gemm_global_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  (void)resize_args;
+
+  const ValueRef out = args.at(0).refs.at(0);
+  const auto out_sizes = graph->sizes_of(out);
+
+  const uint32_t M = out_sizes.at(out_sizes.size() - 2);
+  const uint32_t N = out_sizes.at(out_sizes.size() - 1);
+
+  const uint32_t num_tiles_n = (N + kDefaultTileN - 1) / kDefaultTileN;
+  const uint32_t num_tiles_m = (M + kDefaultTileM - 1) / kDefaultTileM;
+
+  return {num_tiles_n * kInvocationsPerWorkgroup, num_tiles_m, 1};
+}
+
+// Local workgroup size: 256 threads (8 subgroups x 32 threads)
+utils::uvec3 khr_cm_gemm_local_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const utils::uvec3& global_workgroup_size,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)graph;
+  (void)shader;
+  (void)global_workgroup_size;
+  (void)args;
+  (void)resize_args;
+  return {kInvocationsPerWorkgroup, 1, 1};
+}
+
+//
+// Specialization constants (shared by matmul and addmm variants)
+//
+
+vkapi::SpecVarList khr_cm_spec_vars() {
+  return {
+      SV(kDefaultLM), // lM (ID 3)
+      SV(kDefaultLN), // lN (ID 4)
+      SV(kDefaultLK), // lK (ID 5)
+      SV(kDefaultTileM), // TILE_M (ID 6)
+      SV(kDefaultTileN), // TILE_N (ID 7)
+      SV(kDefaultTileK), // TILE_K (ID 8)
+      SV(kDefaultARowLen), // A_ROW_LEN (ID 9)
+      SV(kDefaultANumRows), // A_NUM_ROWS (ID 10)
+      SV(kDefaultBRowLen), // B_ROW_LEN (ID 11)
+      SV(kDefaultBNumRows), // B_NUM_ROWS (ID 12)
+      SV(0u), // BColMajor_val (ID 13) - row major
+  };
+}
+
+//
+// Operator implementations
+//
+
+// D = A * B (matmul, no bias)
+void khr_cm_matmul_impl(
+    ComputeGraph& graph,
+    const ValueRef input_A,
+    const ValueRef input_B,
+    const ValueRef output_D) {
+  VK_CHECK_COND(
+      graph.context()->adapter_ptr()->supports_cooperative_matrix(),
+      "khr_cm_gemm requires VK_KHR_cooperative_matrix extension which is "
+      "not available on this device.");
+
+  const auto A_sizes = graph.sizes_of(input_A);
+  const auto B_sizes = graph.sizes_of(input_B);
+
+  const uint32_t M = A_sizes.at(A_sizes.size() - 2);
+  const uint32_t K_val = A_sizes.at(A_sizes.size() - 1);
+  const uint32_t N = B_sizes.at(B_sizes.size() - 1);
+
+  const uint32_t strideA = K_val;
+  const uint32_t strideB = N;
+  const uint32_t strideD = N;
+
+  KhrCmPushBlock1 pb1 = {K_val, strideA, strideB, 0};
+  KhrCmPushBlock2 pb2 = {strideD, 1.0f, 0.0f};
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      pick_matmul_khr_cm_shader,
+      khr_cm_gemm_global_wg_size,
+      khr_cm_gemm_local_wg_size,
+      {{output_D, vkapi::kWrite}, {{input_A, input_B}, vkapi::kRead}},
+      {},
+      {PushConstantDataInfo(&pb1, sizeof(pb1)),
+       PushConstantDataInfo(&pb2, sizeof(pb2))},
+      khr_cm_spec_vars(),
+      {},
+      resize_khr_cm_gemm_node));
+}
+
+// D = alpha * A * B + beta * C (addmm, with bias)
+void khr_cm_addmm_impl(
+    ComputeGraph& graph,
+    const ValueRef input_A,
+    const ValueRef input_B,
+    const ValueRef input_C,
+    const ValueRef output_D,
+    const float alpha,
+    const float beta) {
+  VK_CHECK_COND(
+      graph.context()->adapter_ptr()->supports_cooperative_matrix(),
+      "khr_cm_gemm requires VK_KHR_cooperative_matrix extension which is "
+      "not available on this device.");
+
+  const auto A_sizes = graph.sizes_of(input_A);
+  const auto B_sizes = graph.sizes_of(input_B);
+
+  const uint32_t K_val = A_sizes.at(A_sizes.size() - 1);
+  const uint32_t N = B_sizes.at(B_sizes.size() - 1);
+
+  const uint32_t strideA = K_val;
+  const uint32_t strideB = N;
+  const uint32_t strideC = N;
+  const uint32_t strideD = N;
+
+  KhrCmPushBlock1 pb1 = {K_val, strideA, strideB, strideC};
+  KhrCmPushBlock2 pb2 = {strideD, alpha, beta};
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      pick_addmm_khr_cm_shader,
+      khr_cm_gemm_global_wg_size,
+      khr_cm_gemm_local_wg_size,
+      {{output_D, vkapi::kWrite}, {{input_A, input_B, input_C}, vkapi::kRead}},
+      {},
+      {PushConstantDataInfo(&pb1, sizeof(pb1)),
+       PushConstantDataInfo(&pb2, sizeof(pb2))},
+      khr_cm_spec_vars(),
+      {},
+      resize_khr_cm_gemm_node));
+}
+
+//
+// Registered operator entry points
+//
+
+// etvk.khr_cm_gemm.default(A, B, C, alpha, beta) -> D
+// General GEMM: D = alpha * A * B + beta * C
+void khr_cm_gemm(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  int idx = 0;
+  const ValueRef input_A = args.at(idx++); // [M, K]
+  const ValueRef input_B = args.at(idx++); // [K, N]
+  const ValueRef input_C = args.at(idx++); // [M, N]
+  const ValueRef alpha_ref = args.at(idx++);
+  const ValueRef beta_ref = args.at(idx++);
+  const ValueRef output_D = args.at(idx++); // [M, N]
+
+  float alpha_val = graph.extract_scalar<double>(alpha_ref);
+  float beta_val = graph.extract_scalar<double>(beta_ref);
+
+  if (beta_val == 0.0f) {
+    khr_cm_matmul_impl(graph, input_A, input_B, output_D);
+  } else {
+    khr_cm_addmm_impl(
+        graph, input_A, input_B, input_C, output_D, alpha_val, beta_val);
+  }
+}
+
+//
+// Int8 cooperative matrix GEMM
+//
+
+// Simplified push constants for int8 (no alpha/beta)
+struct KhrCmInt8PushBlock {
+  uint32_t K;
+  uint32_t strideA;
+  uint32_t strideB;
+  uint32_t strideD;
+};
+
+vkapi::ShaderInfo pick_matmul_khr_cm_int8_shader(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)graph;
+  (void)args;
+  (void)resize_args;
+  return VK_KERNEL_FROM_STR("matmul_khr_cm_int8");
+}
+
+// D = A * B (int8 × int8 → int32)
+void khr_cm_matmul_int8_impl(
+    ComputeGraph& graph,
+    const ValueRef input_A,
+    const ValueRef input_B,
+    const ValueRef output_D) {
+  VK_CHECK_COND(
+      graph.context()->adapter_ptr()->supports_cooperative_matrix(),
+      "khr_cm_gemm_int8 requires VK_KHR_cooperative_matrix extension which is "
+      "not available on this device.");
+
+  const auto A_sizes = graph.sizes_of(input_A);
+  const auto B_sizes = graph.sizes_of(input_B);
+
+  const uint32_t K_val = A_sizes.at(A_sizes.size() - 1);
+  const uint32_t N = B_sizes.at(B_sizes.size() - 1);
+
+  const uint32_t strideA = K_val;
+  const uint32_t strideB = N;
+  const uint32_t strideD = N;
+
+  KhrCmInt8PushBlock pb = {K_val, strideA, strideB, strideD};
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      pick_matmul_khr_cm_int8_shader,
+      khr_cm_gemm_global_wg_size,
+      khr_cm_gemm_local_wg_size,
+      {{output_D, vkapi::kWrite}, {{input_A, input_B}, vkapi::kRead}},
+      {},
+      {PushConstantDataInfo(&pb, sizeof(pb))},
+      khr_cm_spec_vars(),
+      {},
+      resize_khr_cm_gemm_node));
+}
+
+// etvk.khr_cm_gemm_int8.default(A, B) -> D
+void khr_cm_gemm_int8(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  const ValueRef input_A = args.at(0); // [M, K] int8
+  const ValueRef input_B = args.at(1); // [K, N] int8
+  const ValueRef output_D = args.at(2); // [M, N] int32
+
+  khr_cm_matmul_int8_impl(graph, input_A, input_B, output_D);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(etvk.khr_cm_gemm.default, khr_cm_gemm);
+  VK_REGISTER_OP(etvk.khr_cm_gemm_int8.default, khr_cm_gemm_int8);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -119,6 +119,9 @@ VkDevice create_logical_device(
 #ifdef VK_KHR_shader_integer_dot_product
       VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME,
 #endif /* VK_KHR_shader_integer_dot_product */
+#ifdef VK_KHR_cooperative_matrix
+      VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME,
+#endif /* VK_KHR_cooperative_matrix */
 #if defined(VK_KHR_pipeline_executable_properties) && \
     defined(ETVK_INSPECT_PIPELINES)
       VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME,
@@ -178,6 +181,13 @@ VkDevice create_logical_device(
   shader_int_dot_product_features.pNext = extension_list_top;
   extension_list_top = &shader_int_dot_product_features;
 #endif /* VK_KHR_shader_integer_dot_product */
+
+#ifdef VK_KHR_cooperative_matrix
+  VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features{
+      physical_device.cooperative_matrix_features};
+  cooperative_matrix_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix_features;
+#endif /* VK_KHR_cooperative_matrix */
 
   device_create_info.pNext = extension_list_top;
 

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -221,6 +221,15 @@ class Adapter final {
 #endif /* VK_KHR_shader_integer_dot_product */
   }
 
+  inline bool supports_cooperative_matrix() {
+#ifdef VK_KHR_cooperative_matrix
+    return physical_device_.cooperative_matrix_features.cooperativeMatrix ==
+        VK_TRUE;
+#else
+    return false;
+#endif /* VK_KHR_cooperative_matrix */
+  }
+
   inline bool supports_int16_shader_types() {
     return physical_device_.supports_int16_shader_types;
   }

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -43,6 +43,10 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
       shader_int_dot_product_properties{
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR},
 #endif
+#ifdef VK_KHR_cooperative_matrix
+      cooperative_matrix_features{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR},
+#endif /* VK_KHR_cooperative_matrix */
       queue_families{},
       num_compute_queues(0),
       supports_int16_shader_types(false),
@@ -92,6 +96,11 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
   shader_int_dot_product_properties.pNext = extension_list_top;
   extension_list_top = &shader_int_dot_product_properties;
 #endif /* VK_KHR_shader_integer_dot_product */
+
+#ifdef VK_KHR_cooperative_matrix
+  cooperative_matrix_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix_features;
+#endif /* VK_KHR_cooperative_matrix */
 
   features2.pNext = extension_list_top;
 

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -50,6 +50,9 @@ struct PhysicalDevice final {
   VkPhysicalDeviceShaderIntegerDotProductProperties
       shader_int_dot_product_properties;
 #endif /* VK_KHR_shader_integer_dot_product */
+#ifdef VK_KHR_cooperative_matrix
+  VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features;
+#endif /* VK_KHR_cooperative_matrix */
 
   // Available GPU queues
   std::vector<VkQueueFamilyProperties> queue_families;

--- a/backends/vulkan/test/custom_ops/CMakeLists.txt
+++ b/backends/vulkan/test/custom_ops/CMakeLists.txt
@@ -48,8 +48,10 @@ if(TARGET vulkan_backend)
 
   # Prototyping utility files
   set(PROTOTYPING_UTILS_HEADERS ${CMAKE_CURRENT_SOURCE_DIR})
-  set(PROTOTYPING_UTILS_CPP ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
-                            ${CMAKE_CURRENT_SOURCE_DIR}/conv2d_utils.cpp
+  set(PROTOTYPING_UTILS_CPP
+      ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/conv2d_utils.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/cm_utils.cpp
   )
 
   # Prototyping shaders
@@ -101,4 +103,7 @@ if(TARGET vulkan_backend)
   add_operator_prototype(q8ta_q8csw_q8to_conv2d)
   add_operator_prototype(q8ta_q8csw_q8to_conv2d_dw)
   add_operator_prototype(q8ta_q8ta_q8to_add)
+  add_operator_prototype(matmul_benchmark)
+  add_operator_prototype(khr_cm_gemm)
+  add_operator_prototype(khr_cm_gemm_int8)
 endif()

--- a/backends/vulkan/test/custom_ops/cm_utils.cpp
+++ b/backends/vulkan/test/custom_ops/cm_utils.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "cm_utils.h"
+
+#include <executorch/backends/vulkan/runtime/api/Context.h>
+#include <executorch/backends/vulkan/runtime/vk_api/Runtime.h>
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace executorch {
+namespace vulkan {
+namespace prototyping {
+
+static std::string componentTypeToString(VkComponentTypeKHR type) {
+  switch (type) {
+    case VK_COMPONENT_TYPE_FLOAT16_KHR:
+      return "float16";
+    case VK_COMPONENT_TYPE_FLOAT32_KHR:
+      return "float32";
+    case VK_COMPONENT_TYPE_FLOAT64_KHR:
+      return "float64";
+    case VK_COMPONENT_TYPE_SINT8_KHR:
+      return "int8";
+    case VK_COMPONENT_TYPE_SINT16_KHR:
+      return "int16";
+    case VK_COMPONENT_TYPE_SINT32_KHR:
+      return "int32";
+    case VK_COMPONENT_TYPE_SINT64_KHR:
+      return "int64";
+    case VK_COMPONENT_TYPE_UINT8_KHR:
+      return "uint8";
+    case VK_COMPONENT_TYPE_UINT16_KHR:
+      return "uint16";
+    case VK_COMPONENT_TYPE_UINT32_KHR:
+      return "uint32";
+    case VK_COMPONENT_TYPE_UINT64_KHR:
+      return "uint64";
+    default:
+      return "unknown(" + std::to_string(static_cast<int>(type)) + ")";
+  }
+}
+
+static std::string scopeToString(VkScopeKHR scope) {
+  switch (scope) {
+    case VK_SCOPE_DEVICE_KHR:
+      return "Device";
+    case VK_SCOPE_WORKGROUP_KHR:
+      return "Workgroup";
+    case VK_SCOPE_SUBGROUP_KHR:
+      return "Subgroup";
+    case VK_SCOPE_QUEUE_FAMILY_KHR:
+      return "QueueFamily";
+    default:
+      return "unknown(" + std::to_string(static_cast<int>(scope)) + ")";
+  }
+}
+
+void queryCooperativeMatrixProperties() {
+#ifdef VK_KHR_cooperative_matrix
+  auto* adapter = vkcompute::api::context()->adapter_ptr();
+  VkPhysicalDevice physicalDevice = adapter->physical_handle();
+
+  if (!adapter->supports_cooperative_matrix()) {
+    std::cout << "VK_KHR_cooperative_matrix is NOT supported on this device."
+              << std::endl;
+    return;
+  }
+
+  std::cout << "\n=== Cooperative Matrix Properties (KHR) ===" << std::endl;
+
+  uint32_t count = 0;
+  VkResult result = vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(
+      physicalDevice, &count, nullptr);
+
+  if (result != VK_SUCCESS || count == 0) {
+    std::cout << "No cooperative matrix configurations found." << std::endl;
+    return;
+  }
+
+  std::vector<VkCooperativeMatrixPropertiesKHR> properties(count);
+  for (auto& prop : properties) {
+    prop.sType = VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR;
+    prop.pNext = nullptr;
+  }
+
+  result = vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(
+      physicalDevice, &count, properties.data());
+
+  if (result != VK_SUCCESS) {
+    std::cerr << "Failed to query cooperative matrix properties." << std::endl;
+    return;
+  }
+
+  std::cout << "Found " << count << " cooperative matrix configurations:\n"
+            << std::endl;
+
+  std::cout << std::left << std::setw(5) << "#" << std::setw(10) << "M"
+            << std::setw(10) << "N" << std::setw(10) << "K" << std::setw(12)
+            << "AType" << std::setw(12) << "BType" << std::setw(12) << "CType"
+            << std::setw(12) << "ResultType" << std::setw(12) << "Scope"
+            << std::endl;
+
+  std::cout << std::string(95, '-') << std::endl;
+
+  for (uint32_t i = 0; i < count; ++i) {
+    const auto& p = properties[i];
+    std::cout << std::left << std::setw(5) << i << std::setw(10) << p.MSize
+              << std::setw(10) << p.NSize << std::setw(10) << p.KSize
+              << std::setw(12) << componentTypeToString(p.AType)
+              << std::setw(12) << componentTypeToString(p.BType)
+              << std::setw(12) << componentTypeToString(p.CType)
+              << std::setw(12) << componentTypeToString(p.ResultType)
+              << std::setw(12) << scopeToString(p.scope) << std::endl;
+  }
+
+  std::cout << std::endl;
+
+#else
+  std::cout << "VK_KHR_cooperative_matrix not available at compile time."
+            << std::endl;
+#endif
+}
+
+} // namespace prototyping
+} // namespace vulkan
+} // namespace executorch

--- a/backends/vulkan/test/custom_ops/cm_utils.h
+++ b/backends/vulkan/test/custom_ops/cm_utils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace executorch {
+namespace vulkan {
+namespace prototyping {
+
+// Query and print VK_KHR_cooperative_matrix properties from the device.
+// Shows supported M/N/K tile sizes, component types, and scopes.
+void queryCooperativeMatrixProperties();
+
+} // namespace prototyping
+} // namespace vulkan
+} // namespace executorch

--- a/backends/vulkan/test/custom_ops/impl/TestGemm.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestGemm.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+// Test operator that dispatches to either:
+//   impl_selector=0 → aten.mm.default with buffer storage (matmul_naive_buffer)
+//   impl_selector=2 → aten.mm.default with texture3d channels-packed
+//                     (matmul_optimized)
+//
+// Storage type is controlled by ValueSpec in the test harness, not here.
+// Both selectors call the same aten.mm op; the shader selected depends on the
+// tensor storage type set at graph construction time.
+
+void test_gemm(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  int32_t idx = 0;
+  const ValueRef input_A = args.at(idx++); // [M, K]
+  const ValueRef input_B = args.at(idx++); // [K, N]
+  const ValueRef input_C = args.at(idx++); // [M, N] placeholder (unused)
+  const ValueRef alpha_ref = args.at(idx++); // scalar (unused)
+  const ValueRef beta_ref = args.at(idx++); // scalar (unused)
+  const ValueRef impl_selector_ref = args.at(idx++);
+  const ValueRef output = args.at(idx++); // [M, N]
+
+  (void)input_C;
+  (void)alpha_ref;
+  (void)beta_ref;
+
+  int32_t impl_selector = graph.extract_scalar<int32_t>(impl_selector_ref);
+
+  if (impl_selector == 0 || impl_selector == 2) {
+    // aten.mm.default: storage type (buffer vs texture3d) set via ValueSpec
+    std::vector<ValueRef> mm_args = {input_A, input_B, output};
+    VK_GET_OP_FN("aten.mm.default")(graph, mm_args);
+  } else if (impl_selector == 1) {
+    // KHR cooperative matrix FP16 GEMM
+    std::vector<ValueRef> cm_args = {
+        input_A, input_B, input_C, alpha_ref, beta_ref, output};
+    VK_GET_OP_FN("etvk.khr_cm_gemm.default")(graph, cm_args);
+  } else if (impl_selector == 3) {
+    // KHR cooperative matrix int8 GEMM
+    std::vector<ValueRef> cm_int8_args = {input_A, input_B, output};
+    VK_GET_OP_FN("etvk.khr_cm_gemm_int8.default")(graph, cm_int8_args);
+  } else {
+    VK_THROW("Invalid impl_selector value: ", impl_selector);
+  }
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(test_etvk.test_gemm.default, test_gemm);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/matmul_benchmark.cpp
+++ b/backends/vulkan/test/custom_ops/matmul_benchmark.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Side-by-side benchmark of matmul implementations at the same matrix size.
+// Compares:
+//   0  = aten.mm naive buffer        (matmul_naive_buffer, FP16)
+//   1  = KHR CoopMat FP16            (matmul_khr_cm_half)
+//   2  = aten.mm optimized tex3d     (matmul_optimized, FP32)
+//   2b = aten.mm optimized tex3d     (matmul_optimized, FP16)
+//   3  = KHR CoopMat int8            (matmul_khr_cm_int8)
+//   4  = et_vk.linear_q8ta_q8csw    (int8 × int8, buffer)
+//   5  = et_vk.linear_q8csw         (FP16 input × int8 weight, buffer)
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+#include <iostream>
+#include <vector>
+
+#include "cm_utils.h"
+#include "utils.h"
+
+using namespace executorch::vulkan::prototyping;
+using namespace vkcompute;
+
+std::vector<TestCase> generate_benchmark_test_cases() {
+  std::vector<TestCase> test_cases;
+
+  struct BenchConfig {
+    int64_t M;
+    int64_t N;
+    int64_t K;
+    std::string name;
+  };
+
+  std::vector<BenchConfig> configs = {
+      {1024, 1024, 1024, "1024x1024x1024"},
+      {4096, 4096, 4096, "4096x4096x4096"},
+  };
+
+  for (const auto& cfg : configs) {
+    int64_t M = cfg.M, K = cfg.K, N = cfg.N;
+
+    // --- impl 0: aten.mm naive buffer (FP16) ---
+    {
+      TestCase tc;
+      tc.set_name("aten_mm_buffer_" + cfg.name);
+      tc.set_operator_name("test_etvk.test_gemm.default");
+
+      ValueSpec input_A(
+          {M, K},
+          vkapi::kHalf,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT);
+      ValueSpec input_B(
+          {K, N},
+          vkapi::kHalf,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT);
+      ValueSpec input_C(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+      ValueSpec alpha_spec(1.0f);
+      ValueSpec beta_spec(0.0f);
+      ValueSpec impl_selector_spec(static_cast<int32_t>(0));
+      ValueSpec output_D(
+          {M, N},
+          vkapi::kHalf,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+
+      tc.add_input_spec(input_A);
+      tc.add_input_spec(input_B);
+      tc.add_input_spec(input_C);
+      tc.add_input_spec(alpha_spec);
+      tc.add_input_spec(beta_spec);
+      tc.add_input_spec(impl_selector_spec);
+      tc.add_output_spec(output_D);
+      tc.set_shader_filter(
+          {"nchw_to_buffer",
+           "buffer_to_nchw",
+           "nchw_to_image",
+           "image_to_nchw"});
+      tc.set_abs_tolerance(1e10f);
+      tc.set_rel_tolerance(1.0f);
+      test_cases.push_back(tc);
+    }
+
+    // --- impl 1: KHR CoopMat FP16 ---
+    {
+      TestCase tc;
+      tc.set_name("khr_cm_fp16_" + cfg.name);
+      tc.set_operator_name("test_etvk.test_gemm.default");
+
+      ValueSpec input_A(
+          {M, K},
+          vkapi::kHalf,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT);
+      ValueSpec input_B(
+          {K, N},
+          vkapi::kHalf,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT);
+      ValueSpec input_C(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+      ValueSpec alpha_spec(1.0f);
+      ValueSpec beta_spec(0.0f);
+      ValueSpec impl_selector_spec(static_cast<int32_t>(1));
+      ValueSpec output_D(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+
+      tc.add_input_spec(input_A);
+      tc.add_input_spec(input_B);
+      tc.add_input_spec(input_C);
+      tc.add_input_spec(alpha_spec);
+      tc.add_input_spec(beta_spec);
+      tc.add_input_spec(impl_selector_spec);
+      tc.add_output_spec(output_D);
+      tc.set_shader_filter(
+          {"nchw_to_buffer",
+           "buffer_to_nchw",
+           "nchw_to_image",
+           "image_to_nchw"});
+      tc.set_abs_tolerance(1e10f);
+      tc.set_rel_tolerance(1.0f);
+      test_cases.push_back(tc);
+    }
+
+    // --- impl 2: aten.mm optimized texture3d (FP32) ---
+    {
+      TestCase tc;
+      tc.set_name("aten_mm_optimized_fp32_" + cfg.name);
+      tc.set_operator_name("test_etvk.test_gemm.default");
+
+      ValueSpec input_A(
+          {M, K},
+          vkapi::kFloat,
+          utils::kTexture3D,
+          utils::kChannelsPacked,
+          DataGenType::RANDOM);
+      ValueSpec input_B(
+          {K, N},
+          vkapi::kFloat,
+          utils::kTexture3D,
+          utils::kChannelsPacked,
+          DataGenType::RANDOM);
+      ValueSpec input_C(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+      ValueSpec alpha_spec(1.0f);
+      ValueSpec beta_spec(0.0f);
+      ValueSpec impl_selector_spec(static_cast<int32_t>(2));
+      ValueSpec output_D(
+          {M, N},
+          vkapi::kFloat,
+          utils::kTexture3D,
+          utils::kChannelsPacked,
+          DataGenType::ZEROS);
+
+      tc.add_input_spec(input_A);
+      tc.add_input_spec(input_B);
+      tc.add_input_spec(input_C);
+      tc.add_input_spec(alpha_spec);
+      tc.add_input_spec(beta_spec);
+      tc.add_input_spec(impl_selector_spec);
+      tc.add_output_spec(output_D);
+      tc.set_shader_filter(
+          {"nchw_to_buffer",
+           "buffer_to_nchw",
+           "nchw_to_image",
+           "image_to_nchw",
+           "view_"});
+      tc.set_abs_tolerance(1e10f);
+      tc.set_rel_tolerance(1.0f);
+      test_cases.push_back(tc);
+    }
+
+    // --- impl 2b: aten.mm optimized texture3d (FP16) ---
+    {
+      TestCase tc;
+      tc.set_name("aten_mm_optimized_fp16_" + cfg.name);
+      tc.set_operator_name("test_etvk.test_gemm.default");
+
+      ValueSpec input_A(
+          {M, K},
+          vkapi::kHalf,
+          utils::kTexture3D,
+          utils::kChannelsPacked,
+          DataGenType::RANDINT);
+      ValueSpec input_B(
+          {K, N},
+          vkapi::kHalf,
+          utils::kTexture3D,
+          utils::kChannelsPacked,
+          DataGenType::RANDINT);
+      ValueSpec input_C(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+      ValueSpec alpha_spec(1.0f);
+      ValueSpec beta_spec(0.0f);
+      ValueSpec impl_selector_spec(static_cast<int32_t>(2));
+      ValueSpec output_D(
+          {M, N},
+          vkapi::kHalf,
+          utils::kTexture3D,
+          utils::kChannelsPacked,
+          DataGenType::ZEROS);
+
+      tc.add_input_spec(input_A);
+      tc.add_input_spec(input_B);
+      tc.add_input_spec(input_C);
+      tc.add_input_spec(alpha_spec);
+      tc.add_input_spec(beta_spec);
+      tc.add_input_spec(impl_selector_spec);
+      tc.add_output_spec(output_D);
+      tc.set_shader_filter(
+          {"nchw_to_buffer",
+           "buffer_to_nchw",
+           "nchw_to_image",
+           "image_to_nchw",
+           "view_"});
+      tc.set_abs_tolerance(1e10f);
+      tc.set_rel_tolerance(1.0f);
+      test_cases.push_back(tc);
+    }
+
+    // --- impl 3: KHR CoopMat int8 ---
+    {
+      TestCase tc;
+      tc.set_name("khr_cm_int8_" + cfg.name);
+      tc.set_operator_name("test_etvk.test_gemm.default");
+
+      ValueSpec input_A(
+          {M, K},
+          vkapi::kByte,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT8);
+      ValueSpec input_B(
+          {K, N},
+          vkapi::kByte,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT8);
+      ValueSpec input_C(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+      ValueSpec alpha_spec(1.0f);
+      ValueSpec beta_spec(0.0f);
+      ValueSpec impl_selector_spec(static_cast<int32_t>(3));
+      ValueSpec output_D(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+
+      tc.add_input_spec(input_A);
+      tc.add_input_spec(input_B);
+      tc.add_input_spec(input_C);
+      tc.add_input_spec(alpha_spec);
+      tc.add_input_spec(beta_spec);
+      tc.add_input_spec(impl_selector_spec);
+      tc.add_output_spec(output_D);
+      tc.set_shader_filter(
+          {"nchw_to_buffer",
+           "buffer_to_nchw",
+           "nchw_to_image",
+           "image_to_nchw"});
+      tc.set_abs_tolerance(1e10f);
+      tc.set_rel_tolerance(1.0f);
+      test_cases.push_back(tc);
+    }
+
+    // --- impl 4: et_vk.linear_q8ta_q8csw (int8 × int8, buffer) ---
+    {
+      TestCase tc;
+      tc.set_name("et_q8ta_q8csw_buf_" + cfg.name);
+      tc.set_operator_name("et_vk.linear_q8ta_q8csw.default");
+
+      // Float input [M, K]
+      ValueSpec input_tensor(
+          {M, K},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDOM);
+      ValueSpec input_scale(0.008f);
+      ValueSpec input_zero_point(static_cast<int32_t>(-2));
+
+      // Quantized weight: int8 [N, K]
+      ValueSpec quantized_weight(
+          {N, K},
+          vkapi::kChar,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT8);
+      quantized_weight.set_constant(true);
+
+      // Weight sums: per output channel [N]
+      ValueSpec weight_sums(
+          {N},
+          vkapi::kInt,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+      weight_sums.set_constant(true);
+      compute_weight_sums(weight_sums, quantized_weight, N, K);
+
+      // Weight scales: per output channel [N]
+      ValueSpec weight_scales(
+          {N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDOM_SCALES);
+      weight_scales.set_constant(true);
+
+      // No bias
+      ValueSpec bias;
+      bias.set_none(true);
+
+      // Float output [M, N]
+      ValueSpec output(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+
+      tc.add_input_spec(input_tensor);
+      tc.add_input_spec(input_scale);
+      tc.add_input_spec(input_zero_point);
+      tc.add_input_spec(quantized_weight);
+      tc.add_input_spec(weight_sums);
+      tc.add_input_spec(weight_scales);
+      tc.add_input_spec(bias);
+      tc.add_output_spec(output);
+      tc.set_shader_filter(
+          {"nchw_to_buffer",
+           "buffer_to_nchw",
+           "nchw_to_image",
+           "image_to_nchw",
+           "pack_q8"});
+      tc.set_abs_tolerance(1e10f);
+      tc.set_rel_tolerance(1.0f);
+      test_cases.push_back(tc);
+    }
+
+    // --- impl 5: et_vk.linear_q8csw (FP input × int8 weight, buffer) ---
+    {
+      TestCase tc;
+      tc.set_name("et_q8csw_buf_" + cfg.name);
+      tc.set_operator_name("et_vk.linear_q8csw.default");
+
+      // Float input [M, K]
+      ValueSpec input_tensor(
+          {M, K},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDOM);
+
+      // Quantized weight: int8 [N, K]
+      ValueSpec quantized_weight(
+          {N, K},
+          vkapi::kChar,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDINT8);
+      quantized_weight.set_constant(true);
+
+      // Weight scales: per output channel [N]
+      ValueSpec weight_scales(
+          {N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::RANDOM_SCALES);
+      weight_scales.set_constant(true);
+
+      // No bias
+      ValueSpec bias;
+      bias.set_none(true);
+
+      // Float output [M, N]
+      ValueSpec output(
+          {M, N},
+          vkapi::kFloat,
+          utils::kBuffer,
+          utils::kWidthPacked,
+          DataGenType::ZEROS);
+
+      tc.add_input_spec(input_tensor);
+      tc.add_input_spec(quantized_weight);
+      tc.add_input_spec(weight_scales);
+      tc.add_input_spec(bias);
+      tc.add_output_spec(output);
+      tc.set_shader_filter(
+          {"nchw_to_buffer",
+           "buffer_to_nchw",
+           "nchw_to_image",
+           "image_to_nchw",
+           "pack_q8"});
+      tc.set_abs_tolerance(1e10f);
+      tc.set_rel_tolerance(1.0f);
+      test_cases.push_back(tc);
+    }
+  }
+
+  return test_cases;
+}
+
+int64_t benchmark_flop_calculator(const TestCase& test_case) {
+  if (test_case.empty() || test_case.num_inputs() < 2) {
+    return 0;
+  }
+  const auto& A_sizes = test_case.inputs()[0].get_tensor_sizes();
+  int64_t M = A_sizes.at(A_sizes.size() - 2);
+  int64_t K = A_sizes.at(A_sizes.size() - 1);
+  const auto& out_sizes = test_case.outputs()[0].get_tensor_sizes();
+  int64_t N = out_sizes.at(out_sizes.size() - 1);
+  return 2 * M * N * K;
+}
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+
+  set_print_output(false);
+  set_print_latencies(true);
+  set_use_gpu_timestamps(true);
+
+  print_performance_header();
+  std::cout << "Matmul Benchmark" << std::endl;
+  std::cout << "Comparing: naive buffer | KHR CM FP16 | optimized tex3d "
+               "FP32/FP16 | KHR CM int8 | q8ta_q8csw | q8csw"
+            << std::endl;
+  print_separator();
+
+  try {
+    api::context()->initialize_querypool();
+  } catch (const std::exception& e) {
+    std::cerr << "Failed to initialize Vulkan context: " << e.what()
+              << std::endl;
+    return 1;
+  }
+
+  queryCooperativeMatrixProperties();
+
+  if (!api::context()->adapter_ptr()->supports_cooperative_matrix()) {
+    std::cerr << "VK_KHR_cooperative_matrix not supported on this device. "
+              << "KHR CoopMat cases will be skipped at dispatch." << std::endl;
+  }
+
+  execute_test_cases(
+      generate_benchmark_test_cases,
+      benchmark_flop_calculator,
+      "MATMUL_BASELINE",
+      3, // warmup_runs
+      10, // benchmark_runs
+      nullptr); // no reference compute — performance only
+
+  return 0;
+}


### PR DESCRIPTION
Add KHR cooperative matrix FP16 and int8 GEMM implementations using GL_KHR_cooperative_matrix hardware MMA tiles (16x16x16).

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
