### PR TITLE
[ET-VK] Fix under-allocated int_input_sums buffer in dynamic quant linear

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
@@ -658,10 +658,18 @@ void quantized_linear_impl(
     num_groups = graph.size_at<int64_t>(-2, weight_scales_data);
   }
 
+  // Per-(group, M-row) int32 sums of the quantized input, written by the
+  // quantize_and_pack shader as one ivec4 per (group, m4) at index
+  // group * M4 + m4 — so the buffer must hold num_groups * align4(M) int32
+  // elements. The previous {num_groups, K} shape with the output's (fp16)
+  // dtype allocates 2*G*K bytes where 4*G*M are needed, silently
+  // under-allocating whenever K < 2*M and corrupting the sums (and with
+  // them every output of the tiled dq8ca path).
+  const int64_t M = utils::val_at(-2, input_sizes);
   TmpTensor int_input_sums(
       &graph,
-      {num_groups, K},
-      graph.dtype_of(output),
+      {num_groups, utils::align_up_4(M)},
+      vkapi::kInt,
       utils::kBuffer,
       utils::kWidthPacked);
 


### PR DESCRIPTION
## Bug

`add_quantized_linear_dqa_qw_nodes` allocates the `int_input_sums` temporary as `{num_groups, K}` with the **output tensor's (fp16) dtype**:

```cpp
TmpTensor int_input_sums(&graph, {num_groups, K}, graph.dtype_of(output), ...);
```

But the `quantize_and_pack_4h4w_with_group_sums` shader writes one **int32** sum per (quant group, input row) — one `ivec4` per `(group, m4)` block at index `group * M4 + m4` — so the buffer needs `num_groups * align4(M)` int32 elements (4·G·M bytes), while 2·G·K bytes are allocated.

**Whenever `K < 2*M` the buffer is silently too small**, the sums are corrupted, and every output of the dynamically quantized linear path is wrong (validated on a Samsung Xclipse 970 device: ~90% of output elements mismatch a CPU fp32 reference at M=128, K=128, N=128, group_size=64; both texture and buffer storage flavors are affected).

This went unnoticed because common LLM linear shapes have K >= 2*M for short sequences. Long prefills cross the line — e.g. any 4096-wide projection with more than 2048 prefill tokens.

Introduced in 1882ea169 (#14098).

## Fix

Size the temporary as `{num_groups, align4(M)}` with `vkapi::kInt`, matching what the producer shader writes and the consumer reads.

## Validation

On-device (Xclipse 970) microbench sweep over {64,128,256}^3 shape combinations x texture/buffer storage: all previously-failing shapes (every K < 2*M combination) now match the CPU fp32 reference within tolerance; previously-passing shapes and M=1024 Llama-shape performance are unchanged.

Note: intended for upstreaming to pytorch/executorch after review here.

Authored with Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)